### PR TITLE
use chromium-min on Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ai-sdk/togetherai": "1.0.23",
         "@langchain/core": "1.1.18",
         "@langchain/textsplitters": "1.0.0",
-        "@sparticuz/chromium": "143.0.4",
+        "@sparticuz/chromium-min": "143.0.4",
         "@supabase/supabase-js": "2.84.0",
         "@tailwindcss/postcss": "4.1.14",
         "ai": "5.0.68",
@@ -1882,10 +1882,10 @@
         "win32"
       ]
     },
-    "node_modules/@sparticuz/chromium": {
+    "node_modules/@sparticuz/chromium-min": {
       "version": "143.0.4",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-143.0.4.tgz",
-      "integrity": "sha512-/6I7uQTRhRDD2/gGPQ1Gkf+Dqk0RYDACPJDZfSzz0OWk4JmUTonNHPXbrn6UIklOHlnDLf8xAAzkOZKB/cJpLA==",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium-min/-/chromium-min-143.0.4.tgz",
+      "integrity": "sha512-vAV731SUEVH0FUmMc+404ZoRq0glq7DlhEGpAX0C7/rXupZ0HasOIJHbrjNNNE+VElenkdmwBm8MVTzwYcFPyQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ai-sdk/togetherai": "1.0.23",
     "@langchain/core": "1.1.18",
     "@langchain/textsplitters": "1.0.0",
-    "@sparticuz/chromium": "143.0.4",
+    "@sparticuz/chromium-min": "143.0.4",
     "@supabase/supabase-js": "2.84.0",
     "@tailwindcss/postcss": "4.1.14",
     "ai": "5.0.68",
@@ -31,13 +31,13 @@
     "tailwindcss": "4.1.14"
   },
   "devDependencies": {
-    "playwright": "1.56.1",
     "@playwright/test": "1.56.1",
     "@tailwindcss/typography": "0.5.19",
     "@types/node": "24.7.0",
     "@types/react": "19.2.2",
     "dotenv": "17.2.3",
     "jsdom": "27.0.1",
+    "playwright": "1.56.1",
     "typescript": "5.9.3",
     "vitest": "3.2.4"
   }

--- a/src/lib/crawler.ts
+++ b/src/lib/crawler.ts
@@ -133,12 +133,14 @@ export async function extractLinks(
 async function getBrowser(): Promise<Browser> {
   if (process.env.VERCEL) {
     // Production (Vercel)
-    const chromium = require("@sparticuz/chromium");
+    const chromium = require("@sparticuz/chromium-min");
     const { chromium: playwright } = require("playwright-core");
     return await playwright.launch({
       args: chromium.args,
       defaultViewport: chromium.defaultViewport,
-      executablePath: await chromium.executablePath(),
+      executablePath: await chromium.executablePath(
+        "https://github.com/Sparticuz/chromium/releases/download/v143.0.4/chromium-v143.0.4-pack.tar",
+      ),
       headless: chromium.headless,
     });
   } else {


### PR DESCRIPTION
## Main changes

- Updated the crawler to use the latest __`@sparticuz/chromium-min` (v143.0.4)__ binary pack, which is compatible with the latest serverless environments and Playwright versions.

- Modified `src/lib/crawler.ts` to point to the official `v143` remote binary URL.

## Background

When using the __`-min` package__, the library does not bundle the browser binaries (to save space). Instead, `executablePath` expects a __URL__ pointing to a `.tar` file that contains the compressed (Brotli) Chromium binary and dependencies.

By providing the GitHub Release URL for the `pack.tar` file:

1. The library downloads this file at runtime (on the first run).
2. It extracts the Brotli files to the `/tmp` directory (which has more space than the function bundle).
3. It decompresses and launches Chromium from there.

This allows us to bypass the 50MB bundle size limit on Vercel while still running a full (headless) browser.
