### PR TITLE
Enable actual release publishing in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           semantic_version: 19
-          dry_run: true # Set to false to actually publish releases
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',


### PR DESCRIPTION
Removed `dry_run` option to enable actual release publishing.